### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on:
       - self-hosted
       - test
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -41,6 +43,8 @@ jobs:
     runs-on:
       - self-hosted
       - test
+    permissions:
+      contents: read
     needs: style
     steps:
       - name: Checkout repo
@@ -58,6 +62,9 @@ jobs:
     runs-on:
       - self-hosted
       - bundle
+    permissions:
+      contents: read
+      packages: write
     needs: tests
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}


### PR DESCRIPTION
Potential fix for [https://github.com/khulnasoft-lab/neopilot/security/code-scanning/30](https://github.com/khulnasoft-lab/neopilot/security/code-scanning/30)

To fix the issue, we need to explicitly define the permissions for the workflow and its jobs. The permissions should be set to the minimum required for each job to function correctly. For example:
- `contents: read` for jobs that only need to read repository contents.
- Additional permissions (e.g., `contents: write`) only if a job explicitly requires them.

The `permissions` block can be added at the workflow level to apply to all jobs or at the job level for more granular control. In this case, we will add job-specific permissions to ensure each job has only the access it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Explicitly add job-level permissions to the release_nightly GitHub Actions workflow to enforce least privilege and address the code scanning alert for missing permissions.

Bug Fixes:
- Resolve code scanning alert by specifying permissions in the workflow jobs

CI:
- Define minimal `contents: read` permissions for style and test jobs
- Grant `packages: write` in addition to `contents: read` for the bundle job